### PR TITLE
xtail() final_result object appears to have columns reported in incorrect order

### DIFF
--- a/R/xtail.R
+++ b/R/xtail.R
@@ -171,7 +171,7 @@ xtail <- function(mrna, rpf, condition, baseLevel = NA, minMeanCount = 1, normal
 	#result data frame
 	condition1_TE <- paste0(baseLevel,"_log2TE")
 	condition2_TE <- paste0(unique(condition)[2], "_log2TE")
-	final_result <- cbind(result_log2R[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")],result_log2FC[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")])
+	final_result <- cbind(result_log2FC[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")],result_log2R[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")])
 	colnames(final_result) <- c("mRNA_log2FC","RPF_log2FC","log2FC_TE_v1","pvalue_v1",condition1_TE,condition2_TE,"log2FC_TE_v2","pvalue_v2")
 	final_result <- as.data.frame(final_result)
 	final_result$log2FC_TE_final <- 0


### PR DESCRIPTION
Modified line 174 in the xtail() function in the xtail.R file (Xtail version 1.1.5). The final_result object appeared to have the columns in the wrong order (i.e. the FC columns were mixed up with the Ratio's columns). This would affect the downstream plotting function and other analyses.

If you run the xtail() function with normalize=FALSE, you can easily see that the log2FC values are being switched with the log2R vlaues due to this apparent mislabeling. If someone was to use these results for plotting or further downstream analyses, it could lead to aberrant results. 