### PR TITLE
xtail plotFCs() function omits ylim value

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -60,7 +60,7 @@ plotFCs <- function(object, log2FC.cutoff = 1, cex=1, xlim, ylim, ..., cex.lab, 
 	variable <- which(abs(resultsTable$mRNA_log2FC - resultsTable$RPF_log2FC) <= log2FC.cutoff |
 				(abs(resultsTable$mRNA_log2FC) < log2FC.cutoff & abs(resultsTable$RPF_log2FC) < log2FC.cutoff))
 	plot(resultsTable$mRNA_log2FC[variable],resultsTable$RPF_log2FC[variable],pch=pch,col="gray90",
-		xlim=xlim,xlab = "mRNA log2FC", ylab="RPF log2FC",frame.plot=TRUE,cex=cex,
+		xlim=xlim,ylim=ylim,xlab = "mRNA log2FC", ylab="RPF log2FC",frame.plot=TRUE,cex=cex,
 		cex.lab=cex.lab, cex.axis=cex.axis, cex.main=cex.main, cex.sub=cex.sub, ...)
 
 	#mRNA change, RPF stable.

--- a/R/xtail.R
+++ b/R/xtail.R
@@ -171,7 +171,7 @@ xtail <- function(mrna, rpf, condition, baseLevel = NA, minMeanCount = 1, normal
 	#result data frame
 	condition1_TE <- paste0(baseLevel,"_log2TE")
 	condition2_TE <- paste0(unique(condition)[2], "_log2TE")
-	final_result <- cbind(result_log2R[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")],result_log2FC[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")])
+	final_result <- cbind(result_log2FC[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")],result_log2R[,c("log2Ratio1","log2Ratio2","deltaTE","Pval")])
 	colnames(final_result) <- c("mRNA_log2FC","RPF_log2FC","log2FC_TE_v1","pvalue_v1",condition1_TE,condition2_TE,"log2FC_TE_v2","pvalue_v2")
 	final_result <- as.data.frame(final_result)
 	final_result$log2FC_TE_final <- 0


### PR DESCRIPTION
Modified line 63 in the plotFCs() function in the plots.R script (Xtail version 1.1.5). The internal plot call omitted the user-specified 'ylim' argument, so if a user passed a 'ylim' value to the Xtail plotFCs function, it would have no effect on the actual graph. Fixed this by adding the "ylim=ylim" argument in line 63.

To test this bug, try using the plotFCs() function without specifying ylim, and then with ylim=1. You will see that originally, there was no effect on the graph when you tried manually setting ylim. This has been corrected here.